### PR TITLE
feat: LocalDBセットアップ用の設定UI実装 #9

### DIFF
--- a/src/App.Client/ViewModels/DatabaseSettingsViewModel.cs
+++ b/src/App.Client/ViewModels/DatabaseSettingsViewModel.cs
@@ -1,0 +1,399 @@
+using System.Windows.Input;
+using DeskAppKit.Core.Enums;
+using DeskAppKit.Core.Interfaces;
+using DeskAppKit.Infrastructure.Database;
+using DeskAppKit.Infrastructure.Settings.Database;
+
+namespace DeskAppKit.Client.ViewModels;
+
+/// <summary>
+/// データベース設定ViewModel
+/// </summary>
+public class DatabaseSettingsViewModel : ViewModelBase
+{
+    private readonly BootstrapDbManager _bootstrapDbManager;
+    private readonly ILogger _logger;
+    private readonly string _dataDirectory;
+    private readonly string _encryptionKey;
+    private readonly StorageMode _currentStorageMode;
+
+    private string _dbServer = string.Empty;
+    private string _dbName = string.Empty;
+    private string _dbUsername = string.Empty;
+    private string _dbPassword = string.Empty;
+    private bool _useIntegratedSecurity;
+    private string _statusMessage = string.Empty;
+    private bool _isTesting;
+    private bool _isSettingUp;
+    private string _connectionStatus = "未接続";
+    private bool _includeSampleData = true;
+
+    public DatabaseSettingsViewModel(
+        string dataDirectory,
+        string encryptionKey,
+        StorageMode currentStorageMode,
+        ILogger logger)
+    {
+        _dataDirectory = dataDirectory;
+        _encryptionKey = encryptionKey;
+        _currentStorageMode = currentStorageMode;
+        _logger = logger;
+        _bootstrapDbManager = new BootstrapDbManager(dataDirectory, encryptionKey);
+
+        // 現在の設定を読み込み
+        LoadDatabaseConfig();
+
+        // コマンド初期化
+        SetupLocalDbCommand = new RelayCommand(async () => await SetupLocalDbAsync(), () => !IsSettingUp);
+        TestConnectionCommand = new RelayCommand(async () => await TestConnectionAsync(), () => !IsTesting);
+        SaveCommand = new RelayCommand(Save);
+    }
+
+    #region Properties
+
+    /// <summary>
+    /// DBサーバー名
+    /// </summary>
+    public string DbServer
+    {
+        get => _dbServer;
+        set => SetProperty(ref _dbServer, value);
+    }
+
+    /// <summary>
+    /// データベース名
+    /// </summary>
+    public string DbName
+    {
+        get => _dbName;
+        set => SetProperty(ref _dbName, value);
+    }
+
+    /// <summary>
+    /// ユーザー名
+    /// </summary>
+    public string DbUsername
+    {
+        get => _dbUsername;
+        set => SetProperty(ref _dbUsername, value);
+    }
+
+    /// <summary>
+    /// パスワード
+    /// </summary>
+    public string DbPassword
+    {
+        get => _dbPassword;
+        set => SetProperty(ref _dbPassword, value);
+    }
+
+    /// <summary>
+    /// Windows認証を使用
+    /// </summary>
+    public bool UseIntegratedSecurity
+    {
+        get => _useIntegratedSecurity;
+        set
+        {
+            if (SetProperty(ref _useIntegratedSecurity, value))
+            {
+                OnPropertyChanged(nameof(IsUserPasswordEnabled));
+            }
+        }
+    }
+
+    /// <summary>
+    /// ユーザー名/パスワード入力が有効か
+    /// </summary>
+    public bool IsUserPasswordEnabled => !UseIntegratedSecurity;
+
+    /// <summary>
+    /// ステータスメッセージ
+    /// </summary>
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        set => SetProperty(ref _statusMessage, value);
+    }
+
+    /// <summary>
+    /// テスト中フラグ
+    /// </summary>
+    public bool IsTesting
+    {
+        get => _isTesting;
+        set
+        {
+            SetProperty(ref _isTesting, value);
+            (TestConnectionCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        }
+    }
+
+    /// <summary>
+    /// セットアップ中フラグ
+    /// </summary>
+    public bool IsSettingUp
+    {
+        get => _isSettingUp;
+        set
+        {
+            SetProperty(ref _isSettingUp, value);
+            (SetupLocalDbCommand as RelayCommand)?.RaiseCanExecuteChanged();
+        }
+    }
+
+    /// <summary>
+    /// 接続状態
+    /// </summary>
+    public string ConnectionStatus
+    {
+        get => _connectionStatus;
+        set => SetProperty(ref _connectionStatus, value);
+    }
+
+    /// <summary>
+    /// サンプルデータを含める
+    /// </summary>
+    public bool IncludeSampleData
+    {
+        get => _includeSampleData;
+        set => SetProperty(ref _includeSampleData, value);
+    }
+
+    #endregion
+
+    #region Commands
+
+    /// <summary>
+    /// LocalDBセットアップコマンド
+    /// </summary>
+    public ICommand SetupLocalDbCommand { get; }
+
+    /// <summary>
+    /// 接続テストコマンド
+    /// </summary>
+    public ICommand TestConnectionCommand { get; }
+
+    /// <summary>
+    /// 保存コマンド
+    /// </summary>
+    public ICommand SaveCommand { get; }
+
+    #endregion
+
+    #region Private Methods
+
+    /// <summary>
+    /// DB設定読み込み
+    /// </summary>
+    private void LoadDatabaseConfig()
+    {
+        var config = _bootstrapDbManager.Load();
+        if (config != null)
+        {
+            DbServer = config.Server;
+            DbName = config.Database;
+            DbUsername = config.UserId ?? string.Empty;
+            DbPassword = config.Password ?? string.Empty;
+            UseIntegratedSecurity = config.IntegratedSecurity;
+            UpdateConnectionStatus(true);
+        }
+        else
+        {
+            // デフォルト値
+            DbServer = "localhost";
+            DbName = "DeskAppKitDb";
+            UseIntegratedSecurity = true;
+            UpdateConnectionStatus(false);
+        }
+    }
+
+    /// <summary>
+    /// LocalDBセットアップ
+    /// </summary>
+    private async Task SetupLocalDbAsync()
+    {
+        try
+        {
+            IsSettingUp = true;
+            StatusMessage = "LocalDBセットアップを開始しています...";
+
+            var setupService = new LocalDbSetupService(_logger);
+
+            // LocalDB利用可能性チェック
+            var isAvailable = await setupService.IsLocalDbAvailableAsync();
+            if (!isAvailable)
+            {
+                StatusMessage = "LocalDBがインストールされていません";
+                System.Windows.MessageBox.Show(
+                    "SQL Server Express LocalDBがインストールされていません。\n\n" +
+                    "Visual Studio 2022に同梱されているか、以下からダウンロードできます：\n" +
+                    "https://www.microsoft.com/sql-server/sql-server-downloads",
+                    "LocalDB未インストール",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Warning);
+                return;
+            }
+
+            // セットアップ実行
+            var result = await setupService.SetupAsync(_dataDirectory, _encryptionKey);
+
+            if (result.Success)
+            {
+                StatusMessage = "LocalDBセットアップ完了";
+                _logger.Info("DatabaseSettingsViewModel", "LocalDBセットアップ完了");
+
+                // 設定を再読み込み
+                LoadDatabaseConfig();
+
+                // 成功メッセージ表示
+                var stepsMessage = string.Join("\n", result.Steps);
+                System.Windows.MessageBox.Show(
+                    $"LocalDB環境のセットアップが完了しました。\n\n実行ステップ:\n{stepsMessage}\n\n" +
+                    "アプリケーションを再起動してDatabaseモードで使用できます。",
+                    "セットアップ完了",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Information);
+            }
+            else
+            {
+                StatusMessage = $"セットアップ失敗: {result.Message}";
+                _logger.Error("DatabaseSettingsViewModel", $"LocalDBセットアップ失敗: {result.Message}");
+
+                System.Windows.MessageBox.Show(
+                    $"セットアップに失敗しました。\n\n{result.Message}",
+                    "セットアップ失敗",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"エラー: {ex.Message}";
+            _logger.Error("DatabaseSettingsViewModel", "LocalDBセットアップ中にエラー", ex);
+
+            System.Windows.MessageBox.Show(
+                $"セットアップ中にエラーが発生しました。\n\n{ex.Message}",
+                "エラー",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+        finally
+        {
+            IsSettingUp = false;
+        }
+    }
+
+    /// <summary>
+    /// 接続テスト
+    /// </summary>
+    private async Task TestConnectionAsync()
+    {
+        try
+        {
+            IsTesting = true;
+            StatusMessage = "接続テスト中...";
+
+            var config = new BootstrapDbConfig
+            {
+                Server = DbServer,
+                Database = DbName,
+                UserId = UseIntegratedSecurity ? string.Empty : DbUsername,
+                Password = UseIntegratedSecurity ? string.Empty : DbPassword,
+                IntegratedSecurity = UseIntegratedSecurity
+            };
+
+            var canConnect = await _bootstrapDbManager.TestConnectionAsync(config);
+
+            if (canConnect)
+            {
+                StatusMessage = "接続成功";
+                UpdateConnectionStatus(true);
+                _logger.Info("DatabaseSettingsViewModel", "DB接続テスト成功");
+
+                System.Windows.MessageBox.Show(
+                    "データベースへの接続に成功しました。",
+                    "接続成功",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Information);
+            }
+            else
+            {
+                StatusMessage = "接続失敗";
+                UpdateConnectionStatus(false);
+                _logger.Warn("DatabaseSettingsViewModel", "DB接続テスト失敗");
+
+                System.Windows.MessageBox.Show(
+                    "データベースへの接続に失敗しました。\n設定を確認してください。",
+                    "接続失敗",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Warning);
+            }
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"エラー: {ex.Message}";
+            UpdateConnectionStatus(false);
+            _logger.Error("DatabaseSettingsViewModel", "DB接続テスト中にエラー", ex);
+
+            System.Windows.MessageBox.Show(
+                $"接続テスト中にエラーが発生しました。\n\n{ex.Message}",
+                "エラー",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+        finally
+        {
+            IsTesting = false;
+        }
+    }
+
+    /// <summary>
+    /// 設定保存
+    /// </summary>
+    private void Save()
+    {
+        try
+        {
+            var config = new BootstrapDbConfig
+            {
+                Server = DbServer,
+                Database = DbName,
+                UserId = UseIntegratedSecurity ? string.Empty : DbUsername,
+                Password = UseIntegratedSecurity ? string.Empty : DbPassword,
+                IntegratedSecurity = UseIntegratedSecurity
+            };
+
+            _bootstrapDbManager.Save(config);
+            StatusMessage = "設定を保存しました";
+            _logger.Info("DatabaseSettingsViewModel", "DB設定保存完了");
+
+            System.Windows.MessageBox.Show(
+                "データベース設定を保存しました。\nアプリケーションを再起動して変更を反映してください。",
+                "保存完了",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Information);
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"保存エラー: {ex.Message}";
+            _logger.Error("DatabaseSettingsViewModel", "DB設定保存中にエラー", ex);
+
+            System.Windows.MessageBox.Show(
+                $"設定の保存中にエラーが発生しました。\n\n{ex.Message}",
+                "エラー",
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error);
+        }
+    }
+
+    /// <summary>
+    /// 接続状態更新
+    /// </summary>
+    private void UpdateConnectionStatus(bool isConnected)
+    {
+        ConnectionStatus = isConnected ? "✓ 接続済み" : "✗ 未接続";
+    }
+
+    #endregion
+}

--- a/src/App.Client/Views/SettingsWindow.xaml
+++ b/src/App.Client/Views/SettingsWindow.xaml
@@ -18,73 +18,104 @@
             <TextBlock Text="アプリケーション設定" FontSize="24" FontWeight="Bold" Foreground="White"/>
         </Border>
 
-        <!-- コンテンツ -->
-        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Padding="24">
-            <StackPanel>
-                <!-- StorageMode設定 -->
-                <TextBlock Text="ストレージモード" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,12"/>
-                <TextBlock TextWrapping="Wrap" Foreground="#666" Margin="0,0,0,8"
-                           Text="データの保存方法を選択してください。変更後はアプリケーションの再起動が必要です。"/>
+        <!-- タブコントロール -->
+        <TabControl Grid.Row="1" Margin="0">
+            <!-- 一般設定タブ -->
+            <TabItem Header="一般">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="24">
+                    <StackPanel>
+                        <!-- StorageMode設定 -->
+                        <TextBlock Text="ストレージモード" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,12"/>
+                        <TextBlock TextWrapping="Wrap" Foreground="#666" Margin="0,0,0,8"
+                                   Text="データの保存方法を選択してください。変更後はアプリケーションの再起動が必要です。"/>
 
-                <ComboBox ItemsSource="{Binding AvailableStorageModes}"
-                          SelectedItem="{Binding SelectedStorageMode}"
-                          Margin="0,0,0,24" Padding="8" FontSize="14"/>
+                        <ComboBox ItemsSource="{Binding AvailableStorageModes}"
+                                  SelectedItem="{Binding SelectedStorageMode}"
+                                  Margin="0,0,0,24" Padding="8" FontSize="14"/>
 
-                <Separator Margin="0,0,0,24"/>
+                        <Separator Margin="0,0,0,24"/>
 
-                <!-- テーマ設定 -->
-                <TextBlock Text="テーマ" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,12"/>
-                <TextBlock TextWrapping="Wrap" Foreground="#666" Margin="0,0,0,8"
-                           Text="アプリケーションの外観テーマを選択してください。変更は即座に反映されます。"/>
+                        <!-- テーマ設定 -->
+                        <TextBlock Text="テーマ" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,12"/>
+                        <TextBlock TextWrapping="Wrap" Foreground="#666" Margin="0,0,0,8"
+                                   Text="アプリケーションの外観テーマを選択してください。変更は即座に反映されます。"/>
 
-                <ComboBox ItemsSource="{Binding AvailableThemeModes}"
-                          SelectedItem="{Binding SelectedThemeMode}"
-                          Margin="0,0,0,24" Padding="8" FontSize="14"/>
+                        <ComboBox ItemsSource="{Binding AvailableThemeModes}"
+                                  SelectedItem="{Binding SelectedThemeMode}"
+                                  Margin="0,0,0,24" Padding="8" FontSize="14"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
 
-                <Separator Margin="0,0,0,24"/>
+            <!-- データベース設定タブ -->
+            <TabItem Header="データベース">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="24">
+                    <StackPanel DataContext="{Binding DatabaseSettings}">
+                        <!-- 接続状態 -->
+                        <TextBlock Text="現在の接続状態" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                        <TextBlock Text="{Binding ConnectionStatus}" FontSize="14" Foreground="#555" Margin="0,0,0,24"/>
 
-                <!-- データベース設定 -->
-                <TextBlock Text="データベース接続設定" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,12"/>
-                <TextBlock TextWrapping="Wrap" Foreground="#666" Margin="0,0,0,16"
-                           Text="データベースモードを使用する場合の接続情報を設定してください。"/>
+                        <Separator Margin="0,0,0,24"/>
 
-                <!-- サーバー名 -->
-                <TextBlock Text="サーバー名" Margin="0,0,0,4" Foreground="#555"/>
-                <TextBox Text="{Binding DbServer, UpdateSourceTrigger=PropertyChanged}"
-                         Margin="0,0,0,12" Padding="8"/>
+                        <!-- LocalDBセットアップ -->
+                        <TextBlock Text="ローカル開発環境セットアップ" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,12"/>
+                        <TextBlock TextWrapping="Wrap" Foreground="#666" Margin="0,0,0,12"
+                                   Text="LocalDBを使用してローカル開発環境を自動的にセットアップします。"/>
 
-                <!-- データベース名 -->
-                <TextBlock Text="データベース名" Margin="0,0,0,4" Foreground="#555"/>
-                <TextBox Text="{Binding DbName, UpdateSourceTrigger=PropertyChanged}"
-                         Margin="0,0,0,12" Padding="8"/>
+                        <Button Content="ローカルDB環境をセットアップ"
+                                Command="{Binding SetupLocalDbCommand}"
+                                Padding="16,10" HorizontalAlignment="Left" Margin="0,0,0,8"
+                                Background="#1976D2" Foreground="White" BorderThickness="0" Cursor="Hand"
+                                IsEnabled="{Binding IsSettingUp, Converter={StaticResource InverseBooleanConverter}}"/>
 
-                <!-- Windows認証チェックボックス -->
-                <CheckBox Content="Windows認証を使用する"
-                          IsChecked="{Binding UseIntegratedSecurity}"
-                          Margin="0,0,0,12" FontSize="14"/>
+                        <TextBlock Text="{Binding StatusMessage}" Foreground="#666" FontSize="12" Margin="0,0,0,24"/>
 
-                <!-- ユーザー名 -->
-                <TextBlock Text="ユーザー名" Margin="0,0,0,4" Foreground="#555"
-                           IsEnabled="{Binding IsUserPasswordEnabled}"/>
-                <TextBox Text="{Binding DbUsername, UpdateSourceTrigger=PropertyChanged}"
-                         IsEnabled="{Binding IsUserPasswordEnabled}"
-                         Margin="0,0,0,12" Padding="8"/>
+                        <Separator Margin="0,0,0,24"/>
 
-                <!-- パスワード -->
-                <TextBlock Text="パスワード" Margin="0,0,0,4" Foreground="#555"
-                           IsEnabled="{Binding IsUserPasswordEnabled}"/>
-                <PasswordBox x:Name="PasswordBox"
-                             IsEnabled="{Binding IsUserPasswordEnabled}"
-                             PasswordChanged="PasswordBox_PasswordChanged"
-                             Margin="0,0,0,12" Padding="8"/>
+                        <!-- 手動設定 -->
+                        <TextBlock Text="手動データベース設定" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,12"/>
+                        <TextBlock TextWrapping="Wrap" Foreground="#666" Margin="0,0,0,16"
+                                   Text="既存のSQL Serverに接続する場合は、以下の接続情報を設定してください。"/>
 
-                <!-- 接続テストボタン -->
-                <Button Content="接続テスト" Command="{Binding TestConnectionCommand}"
-                        Padding="16,8" HorizontalAlignment="Left"
-                        Background="#4CAF50" Foreground="White" BorderThickness="0" Cursor="Hand"
-                        IsEnabled="{Binding IsTesting, Converter={StaticResource InverseBooleanConverter}}"/>
-            </StackPanel>
-        </ScrollViewer>
+                        <!-- サーバー名 -->
+                        <TextBlock Text="サーバー名" Margin="0,0,0,4" Foreground="#555"/>
+                        <TextBox Text="{Binding DbServer, UpdateSourceTrigger=PropertyChanged}"
+                                 Margin="0,0,0,12" Padding="8"/>
+
+                        <!-- データベース名 -->
+                        <TextBlock Text="データベース名" Margin="0,0,0,4" Foreground="#555"/>
+                        <TextBox Text="{Binding DbName, UpdateSourceTrigger=PropertyChanged}"
+                                 Margin="0,0,0,12" Padding="8"/>
+
+                        <!-- Windows認証チェックボックス -->
+                        <CheckBox Content="Windows認証を使用する"
+                                  IsChecked="{Binding UseIntegratedSecurity}"
+                                  Margin="0,0,0,12" FontSize="14"/>
+
+                        <!-- ユーザー名 -->
+                        <TextBlock Text="ユーザー名" Margin="0,0,0,4" Foreground="#555"
+                                   IsEnabled="{Binding IsUserPasswordEnabled}"/>
+                        <TextBox Text="{Binding DbUsername, UpdateSourceTrigger=PropertyChanged}"
+                                 IsEnabled="{Binding IsUserPasswordEnabled}"
+                                 Margin="0,0,0,12" Padding="8"/>
+
+                        <!-- パスワード -->
+                        <TextBlock Text="パスワード" Margin="0,0,0,4" Foreground="#555"
+                                   IsEnabled="{Binding IsUserPasswordEnabled}"/>
+                        <PasswordBox x:Name="PasswordBox"
+                                     IsEnabled="{Binding IsUserPasswordEnabled}"
+                                     PasswordChanged="PasswordBox_PasswordChanged"
+                                     Margin="0,0,0,16" Padding="8"/>
+
+                        <!-- 接続テストボタン -->
+                        <Button Content="接続テスト" Command="{Binding TestConnectionCommand}"
+                                Padding="16,8" HorizontalAlignment="Left"
+                                Background="#4CAF50" Foreground="White" BorderThickness="0" Cursor="Hand"
+                                IsEnabled="{Binding IsTesting, Converter={StaticResource InverseBooleanConverter}}"/>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+        </TabControl>
 
         <!-- ステータスバー -->
         <Border Grid.Row="2" Background="#F5F5F5" Padding="16" BorderBrush="#E0E0E0" BorderThickness="0,1,0,0">

--- a/src/App.Client/Views/SettingsWindow.xaml.cs
+++ b/src/App.Client/Views/SettingsWindow.xaml.cs
@@ -18,14 +18,14 @@ public partial class SettingsWindow : Window
         DataContext = viewModel;
 
         // 初期パスワード設定
-        PasswordBox.Password = viewModel.DbPassword;
+        PasswordBox.Password = viewModel.DatabaseSettings.DbPassword;
     }
 
     private void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
     {
         if (sender is PasswordBox passwordBox)
         {
-            _viewModel.DbPassword = passwordBox.Password;
+            _viewModel.DatabaseSettings.DbPassword = passwordBox.Password;
         }
     }
 


### PR DESCRIPTION
## 概要
Issue #9の対応として、設定画面にLocalDB環境を1クリックでセットアップできるUIを実装しました。

## 変更点

### 新規実装
1. **DatabaseSettingsViewModel** (Client/ViewModels)
   - LocalDBセットアップコマンド
   - 接続テストコマンド
   - 接続状態表示
   - 手動データベース設定機能
   - セットアップ進捗メッセージ表示

2. **SettingsWindowのタブ構造化**
   - 一般タブ: ストレージモード、テーマ設定
   - データベースタブ: LocalDBセットアップ、手動DB設定

### UI機能
1. **現在の接続状態表示**
   - ✓ 接続済み / ✗ 未接続

2. **ローカルDB環境セットアップ**
   - 「ローカルDB環境をセットアップ」ボタン
   - セットアップ進捗メッセージ表示
   - LocalDB未インストール時の案内表示
   - セットアップ完了/失敗のダイアログ表示

3. **手動データベース設定**
   - サーバー名、データベース名入力
   - Windows認証/SQL認証の選択
   - ユーザー名/パスワード入力
   - 接続テストボタン
   - 設定保存機能

### リファクタリング
- SettingsViewModelからデータベース関連プロパティを分離
- DatabaseSettingsViewModelに集約
- タブごとにViewModelを分離して責任を明確化

## テスト
- [x] ビルド成功（0エラー、0警告）
- [x] 設定画面がタブ構造で表示される
- [x] 一般タブでストレージモード・テーマ設定が可能
- [x] データベースタブでLocalDBセットアップボタンが表示される
- [x] 手動設定機能が正常に動作

## 使用方法
1. メインウィンドウから「設定」を開く
2. 「データベース」タブを選択
3. 「ローカルDB環境をセットアップ」ボタンをクリック
4. セットアップ完了後、アプリケーションを再起動
5. Databaseモードで起動して利用可能

## 技術的考慮事項
- Issue #8のLocalDbSetupServiceを活用
- 非同期処理でUIブロックを防止
- セットアップ中はボタンを無効化
- 既存の手動設定機能は維持

## 次のステップ
- Issue #10: サンプルデータ自動投入機能（オプション）

## 関連Issue
depends on #8

fixes #9