### PR TITLE
feat: LocalモードでのSQLiteサポートとUIThreadデッドロック修正 #11

### DIFF
--- a/src/App.Client/MainWindow.xaml
+++ b/src/App.Client/MainWindow.xaml
@@ -44,7 +44,7 @@
                             <TextBlock Text="通知" VerticalAlignment="Center"/>
                             <Border Background="#F44336" CornerRadius="8" Padding="4,2"
                                     VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,-8,20,0" Width="16" Height="16"
-                                    Visibility="{Binding UnreadNotificationCount, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                    Visibility="{Binding UnreadNotificationCount, Converter={StaticResource BooleanToVisibilityConverter}}" Cursor="">
                                 <TextBlock Text="{Binding UnreadNotificationCount}" Foreground="White"
                                            FontSize="10" FontWeight="Bold"/>
                             </Border>
@@ -90,9 +90,8 @@
 
         <!-- メインコンテンツエリア -->
         <Grid Grid.Row="1">
-            <!-- ContentControl: 各画面ビューをここに動的に表示 -->
-            <ContentControl Content="{Binding CurrentView}">
-                <!-- デフォルトコンテンツ（ビューが指定されていない場合） -->
+            <!-- ホーム画面（デフォルトコンテンツ） -->
+            <ContentControl>
                 <ContentControl.ContentTemplate>
                     <DataTemplate>
                         <Grid Margin="24">

--- a/src/App.Infrastructure/App.Infrastructure.csproj
+++ b/src/App.Infrastructure/App.Infrastructure.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/App.Infrastructure/Database/LocalSqliteSetupService.cs
+++ b/src/App.Infrastructure/Database/LocalSqliteSetupService.cs
@@ -1,0 +1,113 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using DeskAppKit.Core.Interfaces;
+using DeskAppKit.Infrastructure.Persistence.DbContexts;
+using DeskAppKit.Infrastructure.Data;
+
+namespace DeskAppKit.Infrastructure.Database;
+
+/// <summary>
+/// LocalモードでのSQLite初期化サービス
+/// </summary>
+public class LocalSqliteSetupService
+{
+    private readonly ILogger? _logger;
+
+    public LocalSqliteSetupService(ILogger? logger = null)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// SQLiteデータベースをセットアップ
+    /// </summary>
+    public async Task<LocalSqliteSetupResult> SetupAsync(string dataDirectory, bool seedSampleData = true)
+    {
+        var result = new LocalSqliteSetupResult
+        {
+            Success = false,
+            ConnectionString = string.Empty,
+            Steps = new List<string>()
+        };
+
+        try
+        {
+            _logger?.Info("LocalSqliteSetupService", "SQLite初期化開始");
+
+            // 1. データディレクトリ作成
+            if (!Directory.Exists(dataDirectory))
+            {
+                Directory.CreateDirectory(dataDirectory);
+                result.Steps.Add("✓ データディレクトリ作成");
+            }
+
+            // 2. SQLiteファイルパス
+            var dbFilePath = Path.Combine(dataDirectory, "local.db");
+            var connectionString = $"Data Source={dbFilePath}";
+            result.ConnectionString = connectionString;
+
+            _logger?.Info("LocalSqliteSetupService", $"SQLiteファイルパス: {dbFilePath}");
+            result.Steps.Add($"✓ SQLiteファイルパス: {dbFilePath}");
+
+            // 3. DbContext作成とスキーマ生成
+            var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+            optionsBuilder.UseSqlite(connectionString);
+
+            using (var dbContext = new AppDbContext(optionsBuilder.Options))
+            {
+                _logger?.Info("LocalSqliteSetupService", "データベーススキーマ作成中");
+
+                // EnsureCreatedを使用してSQLiteに対応したスキーマを自動生成
+                var created = await dbContext.Database.EnsureCreatedAsync().ConfigureAwait(false);
+                _logger?.Info("LocalSqliteSetupService", $"EnsureCreatedAsync結果: {created}");
+
+                // テーブルが作成されたかを確認
+                var tableExists = await dbContext.Database.CanConnectAsync().ConfigureAwait(false);
+                _logger?.Info("LocalSqliteSetupService", $"DB接続可能: {tableExists}");
+
+                // 4. サンプルデータ投入（同じDbContextインスタンスで実行）
+                if (seedSampleData)
+                {
+                    _logger?.Info("LocalSqliteSetupService", "サンプルデータ投入を開始");
+                    var seeder = new DatabaseSeeder(_logger);
+                    var (userCount, notificationCount) = await seeder.SeedAsync(dbContext).ConfigureAwait(false);
+                    result.Steps.Add($"✓ サンプルユーザー {userCount}件、通知 {notificationCount}件を投入");
+                }
+
+                result.Steps.Add("✓ データベーススキーマ作成完了");
+            }
+
+            // 5. 接続テスト
+            _logger?.Info("LocalSqliteSetupService", "接続テスト");
+            using (var connection = new SqliteConnection(connectionString))
+            {
+                await connection.OpenAsync().ConfigureAwait(false);
+                result.Steps.Add("✓ 接続テスト成功");
+            }
+
+            result.Success = true;
+            _logger?.Info("LocalSqliteSetupService", "SQLite初期化完了");
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger?.Error("LocalSqliteSetupService", "SQLite初期化エラー", ex);
+            result.Steps.Add($"✗ エラー: {ex.Message}");
+            result.ErrorMessage = ex.Message;
+            return result;
+        }
+    }
+
+}
+
+/// <summary>
+/// SQLiteセットアップ結果
+/// </summary>
+public class LocalSqliteSetupResult
+{
+    public bool Success { get; set; }
+    public string ConnectionString { get; set; } = string.Empty;
+    public List<string> Steps { get; set; } = new();
+    public string? ErrorMessage { get; set; }
+}

--- a/src/App.Infrastructure/Persistence/DbContexts/AppDbContext.cs
+++ b/src/App.Infrastructure/Persistence/DbContexts/AppDbContext.cs
@@ -23,6 +23,10 @@ public class AppDbContext : DbContext
     {
         base.OnModelCreating(modelBuilder);
 
+        // DBプロバイダーを検出
+        var isSqlite = Database.IsSqlite();
+        var isSqlServer = Database.IsSqlServer();
+
         // Users
         modelBuilder.Entity<User>(entity =>
         {
@@ -32,6 +36,12 @@ public class AppDbContext : DbContext
             entity.Property(e => e.DisplayName).HasMaxLength(200).IsRequired();
             entity.Property(e => e.PasswordHash).HasMaxLength(500).IsRequired();
             entity.Property(e => e.Salt).HasMaxLength(200).IsRequired();
+
+            // SQLiteの場合、GuidをTEXT型として扱う
+            if (isSqlite)
+            {
+                entity.Property(e => e.UserId).HasConversion<string>();
+            }
         });
 
         // Settings
@@ -43,6 +53,12 @@ public class AppDbContext : DbContext
             entity.Property(e => e.Key).HasMaxLength(200).IsRequired();
             entity.Property(e => e.DataType).HasMaxLength(50).IsRequired();
             entity.Property(e => e.Description).HasMaxLength(500);
+
+            if (isSqlite)
+            {
+                entity.Property(e => e.SettingId).HasConversion<string>();
+                entity.Property(e => e.UserId).HasConversion<string>();
+            }
         });
 
         // Logs
@@ -54,6 +70,11 @@ public class AppDbContext : DbContext
             entity.Property(e => e.Logger).HasMaxLength(200).IsRequired();
             entity.Property(e => e.MachineName).HasMaxLength(100).IsRequired();
             entity.Property(e => e.AppVersion).HasMaxLength(50).IsRequired();
+
+            if (isSqlite)
+            {
+                entity.Property(e => e.LogId).HasConversion<string>();
+            }
         });
 
         // SchemaVersion
@@ -65,6 +86,11 @@ public class AppDbContext : DbContext
             entity.Property(e => e.Version).HasMaxLength(50).IsRequired();
             entity.Property(e => e.MigrationScriptUpPath).HasMaxLength(500);
             entity.Property(e => e.MigrationScriptDownPath).HasMaxLength(500);
+
+            if (isSqlite)
+            {
+                entity.Property(e => e.SchemaVersionId).HasConversion<string>();
+            }
         });
 
         // ClientVersionStatus
@@ -76,6 +102,11 @@ public class AppDbContext : DbContext
             entity.Property(e => e.CurrentAppVersion).HasMaxLength(50).IsRequired();
             entity.Property(e => e.CurrentSchemaVersion).HasMaxLength(50).IsRequired();
             entity.Property(e => e.LastUpdateErrorMessage).HasMaxLength(1000);
+
+            if (isSqlite)
+            {
+                entity.Property(e => e.ClientVersionStatusId).HasConversion<string>();
+            }
         });
 
         // Notifications
@@ -87,6 +118,12 @@ public class AppDbContext : DbContext
             entity.Property(e => e.Title).HasMaxLength(200).IsRequired();
             entity.Property(e => e.Message).HasMaxLength(2000).IsRequired();
             entity.Property(e => e.Category).HasMaxLength(100);
+
+            if (isSqlite)
+            {
+                entity.Property(e => e.Id).HasConversion<string>();
+                entity.Property(e => e.UserId).HasConversion<string>();
+            }
         });
     }
 }

--- a/src/App.Infrastructure/Settings/Database/BootstrapDbConfig.cs
+++ b/src/App.Infrastructure/Settings/Database/BootstrapDbConfig.cs
@@ -90,14 +90,31 @@ public class BootstrapDbManager
     }
 
     /// <summary>
-    /// 接続テスト
+    /// 接続テスト（非同期版）
     /// </summary>
     public async Task<bool> TestConnectionAsync(BootstrapDbConfig config)
     {
         try
         {
             using var connection = new Microsoft.Data.SqlClient.SqlConnection(config.GetConnectionString());
-            await connection.OpenAsync();
+            await connection.OpenAsync().ConfigureAwait(false);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 接続テスト（同期版）
+    /// </summary>
+    public bool TestConnection(BootstrapDbConfig config)
+    {
+        try
+        {
+            using var connection = new Microsoft.Data.SqlClient.SqlConnection(config.GetConnectionString());
+            connection.Open();
             return true;
         }
         catch

--- a/src/App.Infrastructure/Settings/SettingsService.cs
+++ b/src/App.Infrastructure/Settings/SettingsService.cs
@@ -87,8 +87,8 @@ public class SettingsService : ISettingsService
                 // LocalDBインスタンスを起動（接続テスト前に必要）
                 TryStartLocalDbInstance(dbConfig.Server);
 
-                // 接続テスト（同期的に実行）
-                var canConnect = _bootstrapDbManager.TestConnectionAsync(dbConfig).GetAwaiter().GetResult();
+                // 接続テスト（同期版を使用してデッドロック回避）
+                var canConnect = _bootstrapDbManager.TestConnection(dbConfig);
                 if (!canConnect)
                 {
                     // 接続失敗 → Localにフォールバック


### PR DESCRIPTION
## 概要
LocalモードでSQLiteデータベースをサポートし、UIThreadデッドロック問題を修正しました。これにより、Localモード時にもデータベース機能を使用したテストが可能になります。

## 変更点

### SQLite対応
- **LocalSqliteSetupService追加**: SQLiteデータベースの自動作成・初期化・サンプルデータ投入
- **AppDbContextマルチDB対応**: DBプロバイダー検出機能を実装（SQL Server/SQLite両対応）
  - SQLite使用時はGuid型をstring型に自動変換
- **Localモード初期化改善**: SQLite接続成功時に認証サービス・データ一覧サービスを初期化

### デッドロック修正
- **BootstrapDbConfig**: 同期版TestConnection()メソッド追加
- **SettingsService**: UIThreadでの.GetAwaiter().GetResult()呼び出しを同期版に変更
- **ConfigureAwait(false)追加**: 非同期メソッドにConfigureAwait(false)を追加

### その他
- **XAMLバインディング修正**: MainWindow.xamlの存在しないCurrentViewプロパティ削除
- **エラーハンドリング強化**: 起動時エラーをログファイルに詳細出力

## テスト
- [x] ビルド成功（警告0、エラー0）
- [x] SQLiteデータベース作成成功
- [x] サンプルユーザー2件投入成功（admin/admin123, user/user123）
- [x] サンプル通知12件投入成功
- [x] SQLite用認証サービス初期化成功
- [x] SQLite用データ一覧サービス初期化成功
- [x] アプリケーション起動成功（デッドロック解消）
- [x] Databaseモード起動成功（既存機能に影響なし）

fixes #11